### PR TITLE
Sync to @testing-library/react-hooks@3.4.1

### DIFF
--- a/lib/asyncUtils.d.ts
+++ b/lib/asyncUtils.d.ts
@@ -1,11 +1,13 @@
 import { ResolverType } from "./_types";
 export interface TimeoutOptions {
     timeout?: number;
+    interval?: number;
     suppressErrors?: boolean;
 }
 declare function asyncUtils(addResolver: (resolver: ResolverType) => void): {
-    waitForValueToChange: (selector: () => any, options?: TimeoutOptions) => Promise<void>;
-    waitForNextUpdate: (options?: TimeoutOptions) => Promise<void>;
     wait: (callback: () => any, options?: TimeoutOptions) => Promise<void>;
+    waitFor: (callback: () => any, { interval, timeout, suppressErrors }?: TimeoutOptions) => Promise<void>;
+    waitForNextUpdate: (options?: TimeoutOptions) => Promise<void>;
+    waitForValueToChange: (selector: () => any, options?: TimeoutOptions) => Promise<void>;
 };
 export default asyncUtils;

--- a/lib/asyncUtils.js
+++ b/lib/asyncUtils.js
@@ -70,6 +70,12 @@ var TimeoutError = /** @class */ (function (_super) {
     }
     return TimeoutError;
 }(Error));
+function resolveAfter(ms) {
+    return new Promise(function (resolve) {
+        setTimeout(resolve, ms);
+    });
+}
+var hasWarnedDeprecatedWait = false;
 function asyncUtils(addResolver) {
     var nextUpdatePromise;
     function waitForNextUpdate(options) {
@@ -102,13 +108,13 @@ function asyncUtils(addResolver) {
             });
         });
     }
-    function wait(callback, options) {
-        if (options === void 0) { options = { timeout: 0, suppressErrors: true }; }
+    function waitFor(callback, _a) {
+        var _b = _a === void 0 ? {} : _a, interval = _b.interval, timeout = _b.timeout, _c = _b.suppressErrors, suppressErrors = _c === void 0 ? true : _c;
         return __awaiter(this, void 0, void 0, function () {
             var checkResult, waitForResult;
             var _this = this;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
+            return __generator(this, function (_d) {
+                switch (_d.label) {
                     case 0:
                         checkResult = function () {
                             try {
@@ -116,17 +122,17 @@ function asyncUtils(addResolver) {
                                 return callbackResult || callbackResult === undefined;
                             }
                             catch (err) {
-                                if (!options.suppressErrors) {
+                                if (!suppressErrors) {
                                     throw err;
                                 }
                             }
                         };
                         waitForResult = function () { return __awaiter(_this, void 0, void 0, function () {
-                            var initialTimeout, startTime, err_1;
+                            var initialTimeout, startTime, nextCheck, err_1;
                             return __generator(this, function (_a) {
                                 switch (_a.label) {
                                     case 0:
-                                        initialTimeout = options.timeout;
+                                        initialTimeout = timeout;
                                         _a.label = 1;
                                     case 1:
                                         if (!true) return [3 /*break*/, 6];
@@ -134,7 +140,13 @@ function asyncUtils(addResolver) {
                                         _a.label = 2;
                                     case 2:
                                         _a.trys.push([2, 4, , 5]);
-                                        return [4 /*yield*/, waitForNextUpdate({ timeout: options.timeout })];
+                                        nextCheck = interval
+                                            ? Promise.race([
+                                                waitForNextUpdate({ timeout: timeout }),
+                                                resolveAfter(interval),
+                                            ])
+                                            : waitForNextUpdate({ timeout: timeout });
+                                        return [4 /*yield*/, nextCheck];
                                     case 3:
                                         _a.sent();
                                         if (checkResult()) {
@@ -144,11 +156,11 @@ function asyncUtils(addResolver) {
                                     case 4:
                                         err_1 = _a.sent();
                                         if (err_1.timeout) {
-                                            throw new TimeoutError("wait", { timeout: initialTimeout });
+                                            throw new TimeoutError("waitFor", { timeout: initialTimeout });
                                         }
                                         throw err_1;
                                     case 5:
-                                        options.timeout -= Date.now() - startTime;
+                                        timeout -= Date.now() - startTime;
                                         return [3 /*break*/, 1];
                                     case 6: return [2 /*return*/];
                                 }
@@ -157,8 +169,8 @@ function asyncUtils(addResolver) {
                         if (!!checkResult()) return [3 /*break*/, 2];
                         return [4 /*yield*/, waitForResult()];
                     case 1:
-                        _a.sent();
-                        _a.label = 2;
+                        _d.sent();
+                        _d.label = 2;
                     case 2: return [2 /*return*/];
                 }
             });
@@ -175,7 +187,7 @@ function asyncUtils(addResolver) {
                         _a.label = 1;
                     case 1:
                         _a.trys.push([1, 3, , 4]);
-                        return [4 /*yield*/, wait(function () { return selector() !== initialValue; }, __assign({ suppressErrors: false }, options))];
+                        return [4 /*yield*/, waitFor(function () { return selector() !== initialValue; }, __assign({ suppressErrors: false }, options))];
                     case 2:
                         _a.sent();
                         return [3 /*break*/, 4];
@@ -190,104 +202,40 @@ function asyncUtils(addResolver) {
             });
         });
     }
+    function wait(callback, options) {
+        if (options === void 0) { options = { timeout: 0, suppressErrors: true }; }
+        return __awaiter(this, void 0, void 0, function () {
+            var err_3;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (!hasWarnedDeprecatedWait) {
+                            hasWarnedDeprecatedWait = true;
+                            console.warn("`wait` has been deprecated. Use `waitFor` instead: https://react-hooks-testing-library.com/reference/api#waitfor.");
+                        }
+                        _a.label = 1;
+                    case 1:
+                        _a.trys.push([1, 3, , 4]);
+                        return [4 /*yield*/, waitFor(callback, options)];
+                    case 2:
+                        _a.sent();
+                        return [3 /*break*/, 4];
+                    case 3:
+                        err_3 = _a.sent();
+                        if (err_3.timeout) {
+                            throw new TimeoutError("wait", { timeout: options.timeout });
+                        }
+                        throw err_3;
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    }
     return {
-        waitForValueToChange: waitForValueToChange,
-        waitForNextUpdate: waitForNextUpdate,
         wait: wait,
+        waitFor: waitFor,
+        waitForNextUpdate: waitForNextUpdate,
+        waitForValueToChange: waitForValueToChange,
     };
 }
 exports.default = asyncUtils;
-// function asyncUtils(addResolver: (r: ResolverType) => void) {
-//   let nextUpdatePromise: Promise<any> | null = null;
-//   const waitForNextUpdate = async (
-//     options: TimeoutOptions = { timeout: 0 }
-//   ) => {
-//     if (!nextUpdatePromise) {
-//       nextUpdatePromise = new Promise((resolve, reject) => {
-//         let timeoutId: NodeJS.Timeout;
-//         if (options.timeout && options.timeout > 0) {
-//           timeoutId = setTimeout(
-//             () => reject(new TimeoutError("waitForNextUpdate", options)),
-//             options.timeout
-//           );
-//         }
-//         addResolver(() => {
-//           clearTimeout(timeoutId);
-//           nextUpdatePromise = null;
-//           resolve();
-//         });
-//       });
-//       await act(() => {
-//         if (nextUpdatePromise) {
-//           return nextUpdatePromise;
-//         }
-//         return;
-//       });
-//     }
-//     await nextUpdatePromise;
-//   };
-//   const wait = async (
-//     callback: () => any,
-//     { timeout, suppressErrors }: WaitOptions = {
-//       timeout: 0,
-//       suppressErrors: true,
-//     }
-//   ) => {
-//     const checkResult = () => {
-//       try {
-//         const callbackResult = callback();
-//         return callbackResult || callbackResult === undefined;
-//       } catch (e) {
-//         if (!suppressErrors) {
-//           throw e;
-//         }
-//       }
-//     };
-//     const waitForResult = async () => {
-//       const initialTimeout = timeout;
-//       while (true) {
-//         const startTime = Date.now();
-//         try {
-//           await waitForNextUpdate({ timeout });
-//           if (checkResult()) {
-//             return;
-//           }
-//         } catch (e) {
-//           if (e.timeout) {
-//             throw new TimeoutError("wait", { timeout: initialTimeout });
-//           }
-//           throw e;
-//         }
-//         timeout -= Date.now() - startTime;
-//       }
-//     };
-//     if (!checkResult()) {
-//       await waitForResult();
-//     }
-//   };
-//   const waitForValueToChange = async (
-//     selector: () => any,
-//     options: TimeoutOptions = {
-//       timeout: 0,
-//     }
-//   ) => {
-//     const initialValue = selector();
-//     try {
-//       await wait(() => selector() !== initialValue, {
-//         suppressErrors: false,
-//         ...options,
-//       });
-//     } catch (e) {
-//       if (e.timeout) {
-//         throw new TimeoutError("waitForValueToChange", options);
-//       }
-//       throw e;
-//     }
-//   };
-//   return {
-//     wait,
-//     waitForNextUpdate,
-//     waitForValueToChange,
-//   };
-// }
-// export default asyncUtils;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,1 @@
-import { renderHook } from "./renderHook";
-import { act } from "@testing-library/preact";
-import { cleanup } from "./cleanup";
-export { renderHook, act, cleanup };
+export * from "./pure";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,14 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+}
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -36,21 +46,15 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cleanup = exports.act = exports.renderHook = void 0;
 /* globals afterEach */
-var renderHook_1 = require("./renderHook");
-Object.defineProperty(exports, "renderHook", { enumerable: true, get: function () { return renderHook_1.renderHook; } });
-var preact_1 = require("@testing-library/preact");
-Object.defineProperty(exports, "act", { enumerable: true, get: function () { return preact_1.act; } });
-var cleanup_1 = require("./cleanup");
-Object.defineProperty(exports, "cleanup", { enumerable: true, get: function () { return cleanup_1.cleanup; } });
+var pure_1 = require("./pure");
 // @ts-ignore
 if (typeof afterEach === "function" && !process.env.PHTL_SKIP_AUTO_CLEANUP) {
     // @ts-ignore
     afterEach(function () { return __awaiter(void 0, void 0, void 0, function () {
         return __generator(this, function (_a) {
             switch (_a.label) {
-                case 0: return [4 /*yield*/, cleanup_1.cleanup()];
+                case 0: return [4 /*yield*/, pure_1.cleanup()];
                 case 1:
                     _a.sent();
                     return [2 /*return*/];
@@ -58,3 +62,4 @@ if (typeof afterEach === "function" && !process.env.PHTL_SKIP_AUTO_CLEANUP) {
         });
     }); });
 }
+__exportStar(require("./pure"), exports);

--- a/lib/pure.d.ts
+++ b/lib/pure.d.ts
@@ -1,0 +1,4 @@
+import { renderHook } from "./renderHook";
+import { act } from "@testing-library/preact";
+import { cleanup } from "./cleanup";
+export { renderHook, act, cleanup };

--- a/lib/pure.js
+++ b/lib/pure.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cleanup = exports.act = exports.renderHook = void 0;
+var renderHook_1 = require("./renderHook");
+Object.defineProperty(exports, "renderHook", { enumerable: true, get: function () { return renderHook_1.renderHook; } });
+var preact_1 = require("@testing-library/preact");
+Object.defineProperty(exports, "act", { enumerable: true, get: function () { return preact_1.act; } });
+var cleanup_1 = require("./cleanup");
+Object.defineProperty(exports, "cleanup", { enumerable: true, get: function () { return cleanup_1.cleanup; } });

--- a/lib/renderHook.d.ts
+++ b/lib/renderHook.d.ts
@@ -5,9 +5,10 @@ export interface RenderHookOptions<P> {
     wrapper?: ComponentType;
 }
 export declare function renderHook<P, R>(callback: Callback<P, R>, { initialProps, wrapper }?: RenderHookOptions<P>): {
-    waitForValueToChange: (selector: () => any, options?: import("./asyncUtils").TimeoutOptions) => Promise<void>;
-    waitForNextUpdate: (options?: import("./asyncUtils").TimeoutOptions) => Promise<void>;
     wait: (callback: () => any, options?: import("./asyncUtils").TimeoutOptions) => Promise<void>;
+    waitFor: (callback: () => any, { interval, timeout, suppressErrors }?: import("./asyncUtils").TimeoutOptions) => Promise<void>;
+    waitForNextUpdate: (options?: import("./asyncUtils").TimeoutOptions) => Promise<void>;
+    waitForValueToChange: (selector: () => any, options?: import("./asyncUtils").TimeoutOptions) => Promise<void>;
     result: {
         readonly current: R;
         readonly error: Error;

--- a/lib/renderHook.js
+++ b/lib/renderHook.js
@@ -41,7 +41,6 @@ var resultContainer_1 = __importDefault(require("./resultContainer"));
 var TestComponent_1 = __importStar(require("./TestComponent"));
 var cleanup_1 = require("./cleanup");
 var asyncUtils_1 = __importDefault(require("./asyncUtils"));
-var defaultWrapper = function (Component) { return preact_1.h(Component, null); };
 function renderHook(callback, _a) {
     var _b = _a === void 0 ? {} : _a, initialProps = _b.initialProps, wrapper = _b.wrapper;
     var _c = resultContainer_1.default(), result = _c.result, setValue = _c.setValue, setError = _c.setError, addResolver = _c.addResolver;
@@ -49,7 +48,7 @@ function renderHook(callback, _a) {
         current: initialProps,
     };
     var wrapUiIfNeeded = function (innerElement) {
-        return wrapper ? preact_1.h(wrapper, null, innerElement) : innerElement;
+        return wrapper ? preact_1.h(wrapper, hookProps.current, innerElement) : innerElement;
     };
     var TestHook = function () {
         return wrapUiIfNeeded(preact_1.h(compat_1.Suspense, { fallback: preact_1.h(TestComponent_1.Fallback, null) },

--- a/package.json
+++ b/package.json
@@ -25,15 +25,17 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@testing-library/preact": "^2.0.0",
     "@types/jest": "^25.2.2",
     "jest": "^25",
+    "preact": "^10.4.8",
     "rimraf": "^3.0.2",
     "ts-jest": "^25.5.1",
     "typescript": "^3.9.2"
   },
   "peerDependencies": {
-    "@testing-library/preact": "^1.0.2",
-    "preact": "^10.4.1"
+    "@testing-library/preact": "^2.0.0",
+    "preact": "^10.4.8"
   },
   "dependencies": {}
 }

--- a/pure.js
+++ b/pure.js
@@ -1,0 +1,2 @@
+// makes it so people can import from '@testing-library/react-hooks/pure'
+module.exports = require("./lib/pure");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 /* globals afterEach */
-import { renderHook } from "./renderHook";
-import { act } from "@testing-library/preact";
-import { cleanup } from "./cleanup";
+import { cleanup } from "./pure";
 
 // @ts-ignore
 if (typeof afterEach === "function" && !process.env.PHTL_SKIP_AUTO_CLEANUP) {
@@ -11,4 +9,4 @@ if (typeof afterEach === "function" && !process.env.PHTL_SKIP_AUTO_CLEANUP) {
   });
 }
 
-export { renderHook, act, cleanup };
+export * from "./pure";

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,0 +1,5 @@
+import { renderHook } from "./renderHook";
+import { act } from "@testing-library/preact";
+import { cleanup } from "./cleanup";
+
+export { renderHook, act, cleanup };

--- a/src/renderHook.tsx
+++ b/src/renderHook.tsx
@@ -8,7 +8,6 @@ import TestComponent, { Fallback } from "./TestComponent";
 import { removeCleanup, addCleanup } from "./cleanup";
 import asyncUtils from "./asyncUtils";
 
-const defaultWrapper = (Component: any) => <Component />;
 export interface RenderHookOptions<P> {
   initialProps?: P;
   wrapper?: ComponentType;
@@ -25,7 +24,7 @@ export function renderHook<P, R>(
   };
 
   const wrapUiIfNeeded = (innerElement: any) =>
-    wrapper ? h(wrapper, null, innerElement) : innerElement;
+    wrapper ? h(wrapper, hookProps.current!, innerElement) : innerElement;
 
   const TestHook = () =>
     wrapUiIfNeeded(

--- a/test/asyncHook.test.ts
+++ b/test/asyncHook.test.ts
@@ -82,27 +82,51 @@ describe("async hook tests", () => {
   });
 
   test("should wait for expectation to pass", async () => {
-    const { result, wait } = renderHook(() =>
+    const { result, waitFor } = renderHook(() =>
       useSequence("first", "second", "third")
     );
 
     expect(result.current).toBe("first");
 
     let complete = false;
-    await wait(() => {
+    await waitFor(() => {
       expect(result.current).toBe("third");
       complete = true;
     });
     expect(complete).toBe(true);
   });
 
+  test.only("should wait for arbitrary expectation to pass", async () => {
+    const { waitFor } = renderHook(() => null);
+
+    let actual = 0;
+    let expected = 1;
+
+    setTimeout(() => {
+      actual = expected;
+    }, 200);
+
+    let complete = false;
+    await waitFor(
+      () => {
+        expect(actual).toBe(expected);
+        complete = true;
+      },
+      { interval: 100 }
+    );
+
+    expect(complete).toBe(true);
+  });
+
   test("should not hang if expectation is already passing", async () => {
-    const { result, wait } = renderHook(() => useSequence("first", "second"));
+    const { result, waitFor } = renderHook(() =>
+      useSequence("first", "second")
+    );
 
     expect(result.current).toBe("first");
 
     let complete = false;
-    await wait(() => {
+    await waitFor(() => {
       expect(result.current).toBe("first");
       complete = true;
     });
@@ -110,14 +134,14 @@ describe("async hook tests", () => {
   });
 
   test("should reject if callback throws error", async () => {
-    const { result, wait } = renderHook(() =>
+    const { result, waitFor } = renderHook(() =>
       useSequence("first", "second", "third")
     );
 
     expect(result.current).toBe("first");
 
     await expect(
-      wait(
+      waitFor(
         () => {
           if (result.current === "second") {
             throw new Error("Something Unexpected");
@@ -132,14 +156,14 @@ describe("async hook tests", () => {
   });
 
   test("should reject if callback immediately throws error", async () => {
-    const { result, wait } = renderHook(() =>
+    const { result, waitFor } = renderHook(() =>
       useSequence("first", "second", "third")
     );
 
     expect(result.current).toBe("first");
 
     await expect(
-      wait(
+      waitFor(
         () => {
           throw new Error("Something Unexpected");
         },
@@ -151,33 +175,47 @@ describe("async hook tests", () => {
   });
 
   test("should wait for truthy value", async () => {
-    const { result, wait } = renderHook(() =>
+    const { result, waitFor } = renderHook(() =>
       useSequence("first", "second", "third")
     );
 
     expect(result.current).toBe("first");
 
-    await wait(() => result.current === "third");
+    await waitFor(() => result.current === "third");
 
     expect(result.current).toBe("third");
   });
 
-  // FIXME
-  test.skip("should reject if timeout exceeded when waiting for expectation to pass", async () => {
-    const { result, wait } = renderHook(() =>
+  test("should wait for arbitrary truthy value", async () => {
+    const { waitFor } = renderHook(() => null);
+
+    let actual = 0;
+    let expected = 1;
+
+    setTimeout(() => {
+      actual = expected;
+    }, 200);
+
+    await waitFor(() => actual === 1, { interval: 100 });
+
+    expect(actual).toBe(expected);
+  });
+
+  test("should reject if timeout exceeded when waiting for expectation to pass", async () => {
+    const { result, waitFor } = renderHook(() =>
       useSequence("first", "second", "third")
     );
 
     expect(result.current).toBe("first");
 
     await expect(
-      wait(
+      waitFor(
         () => {
           expect(result.current).toBe("third");
         },
         { timeout: 75 }
       )
-    ).rejects.toThrow(Error("Timed out in wait after 75ms."));
+    ).rejects.toThrow(Error("Timed out in waitFor after 75ms."));
   });
 
   test("should wait for value to change", async () => {
@@ -190,6 +228,21 @@ describe("async hook tests", () => {
     await waitForValueToChange(() => result.current === "third");
 
     expect(result.current).toBe("third");
+  });
+
+  test("should wait for arbitrary value to change", async () => {
+    const { waitForValueToChange } = renderHook(() => null);
+
+    let actual = 0;
+    let expected = 1;
+
+    setTimeout(() => {
+      actual = expected;
+    }, 200);
+
+    await waitForValueToChange(() => actual, { interval: 100 });
+
+    expect(actual).toBe(expected);
   });
 
   test("should reject if timeout exceeded when waiting for value to change", async () => {
@@ -241,5 +294,103 @@ describe("async hook tests", () => {
     );
 
     expect(result.current).toBe("third");
+  });
+
+  test("should wait for expectation to pass (deprecated)", async () => {
+    const { result, wait } = renderHook(() =>
+      useSequence("first", "second", "third")
+    );
+
+    expect(result.current).toBe("first");
+
+    let complete = false;
+    await wait(() => {
+      expect(result.current).toBe("third");
+      complete = true;
+    });
+    expect(complete).toBe(true);
+  });
+
+  test("should not hang if expectation is already passing (deprecated)", async () => {
+    const { result, wait } = renderHook(() => useSequence("first", "second"));
+
+    expect(result.current).toBe("first");
+
+    let complete = false;
+    await wait(() => {
+      expect(result.current).toBe("first");
+      complete = true;
+    });
+    expect(complete).toBe(true);
+  });
+
+  test("should reject if callback throws error (deprecated)", async () => {
+    const { result, wait } = renderHook(() =>
+      useSequence("first", "second", "third")
+    );
+
+    expect(result.current).toBe("first");
+
+    await expect(
+      wait(
+        () => {
+          if (result.current === "second") {
+            throw new Error("Something Unexpected");
+          }
+          return result.current === "third";
+        },
+        {
+          suppressErrors: false,
+        }
+      )
+    ).rejects.toThrow(Error("Something Unexpected"));
+  });
+
+  test("should reject if callback immediately throws error (deprecated)", async () => {
+    const { result, wait } = renderHook(() =>
+      useSequence("first", "second", "third")
+    );
+
+    expect(result.current).toBe("first");
+
+    await expect(
+      wait(
+        () => {
+          throw new Error("Something Unexpected");
+        },
+        {
+          suppressErrors: false,
+        }
+      )
+    ).rejects.toThrow(Error("Something Unexpected"));
+  });
+
+  test("should wait for truthy value (deprecated)", async () => {
+    const { result, wait } = renderHook(() =>
+      useSequence("first", "second", "third")
+    );
+
+    expect(result.current).toBe("first");
+
+    await wait(() => result.current === "third");
+
+    expect(result.current).toBe("third");
+  });
+
+  test("should reject if timeout exceeded when waiting for expectation to pass (deprecated)", async () => {
+    const { result, wait } = renderHook(() =>
+      useSequence("first", "second", "third")
+    );
+
+    expect(result.current).toBe("first");
+
+    await expect(
+      wait(
+        () => {
+          expect(result.current).toBe("third");
+        },
+        { timeout: 75 }
+      )
+    ).rejects.toThrow(Error("Timed out in wait after 75ms."));
   });
 });

--- a/test/useContext.test.tsx
+++ b/test/useContext.test.tsx
@@ -25,7 +25,7 @@ describe("useContext tests", () => {
     expect(result.current).toBe("bar");
   });
 
-  test("should update value in context", () => {
+  test("should update mutated value in context", () => {
     const TestContext = createContext("foo");
 
     const value = { current: "bar" };
@@ -43,6 +43,25 @@ describe("useContext tests", () => {
     value.current = "baz";
 
     rerender();
+
+    expect(result.current).toBe("baz");
+  });
+
+  test("should update value in context when props are updated", () => {
+    const TestContext = createContext("foo");
+
+    const wrapper = ({ current, children }: any) => (
+      <TestContext.Provider value={current}>{children}</TestContext.Provider>
+    );
+
+    const { result, rerender } = renderHook(() => useContext(TestContext), {
+      wrapper,
+      initialProps: {
+        current: "bar",
+      },
+    });
+
+    rerender({ current: "baz" });
 
     expect(result.current).toBe("baz");
   });

--- a/test/useMemo.test.ts
+++ b/test/useMemo.test.ts
@@ -48,15 +48,15 @@ describe("useCallback tests", () => {
 
     const callback1 = result.current;
 
-    const calbackValue1 = callback1();
+    const callbackValue1 = callback1();
 
-    expect(calbackValue1).toEqual({ value: 1 });
+    expect(callbackValue1).toEqual({ value: 1 });
 
     const callback2 = result.current;
 
-    const calbackValue2 = callback2();
+    const callbackValue2 = callback2();
 
-    expect(calbackValue2).toEqual({ value: 1 });
+    expect(callbackValue2).toEqual({ value: 1 });
 
     expect(callback2).toBe(callback1);
 
@@ -64,9 +64,9 @@ describe("useCallback tests", () => {
 
     const callback3 = result.current;
 
-    const calbackValue3 = callback3();
+    const callbackValue3 = callback3();
 
-    expect(calbackValue3).toEqual({ value: 2 });
+    expect(callbackValue3).toEqual({ value: 2 });
 
     expect(callback3).not.toBe(callback1);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.6.tgz#d9aa1f580abf3b2286ef40b6904d390904c63376"
@@ -121,6 +128,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
 "@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
@@ -134,6 +146,15 @@
     "@babel/template" "^7.8.3"
     "@babel/traverse" "^7.9.6"
     "@babel/types" "^7.9.6"
+
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@babel/highlight@^7.8.3":
   version "7.9.0"
@@ -219,18 +240,18 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/runtime-corejs3@^7.7.4":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz#67aded13fffbbc2cb93247388cf84d77a4be9a71"
-  integrity sha512-6toWAfaALQjt3KMZQc6fABqZwUDDuWzz+cAfPhqyEnzxvdWOAkjwPNxgF8xlmo7OWLsSjaKjsskpKHRLaMArOA==
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
   dependencies:
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.5.5", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
-  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -453,15 +474,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -472,10 +484,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
+"@jest/types@^26.3.0":
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
+  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
@@ -484,26 +502,30 @@
   dependencies:
     type-detect "4.0.8"
 
-"@testing-library/dom@^6.1.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
+"@testing-library/dom@^7.16.2":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.1.tgz#0e8acd042070f2c1b183fbfe5c0d38b3194ad3c0"
+  integrity sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
 
-"@testing-library/preact@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/preact/-/preact-1.0.2.tgz#1713ba1878a6b93045040041e216009197e970b1"
-  integrity sha512-V018fHzJksxgX2fJ4S1IzTqQ12TvsXgmSdEXdmOcdWAkoXi724b6Q3c2Kkfz9rVGkb9yBmwPd4YxkZJKqhQtTg==
+"@testing-library/preact@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/preact/-/preact-2.0.0.tgz#bf40faa24136a2388e74655d154fe3538541c33b"
+  integrity sha512-K54AYOnUzMcjK21+6XLfMyb6q8ngBVUXZkirjHMnUoqjarmCHmREzP539U0oKSszWSq7AJxu8M1EYD2YWAIneA==
   dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@testing-library/dom" "^6.1.0"
+    "@testing-library/dom" "^7.16.2"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.7":
   version "7.1.7"
@@ -570,6 +592,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
 "@types/jest@^25.2.2":
   version "25.2.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.2.tgz#6a752e7a00f69c3e790ea00c345029d5cefa92bf"
@@ -598,24 +627,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
-  dependencies:
-    pretty-format "^24.3.0"
-
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.9"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.9.tgz#44028e974343c7afcf3960f1a2b1099c39a7b5e1"
-  integrity sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.5"
@@ -669,7 +684,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -679,7 +694,7 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -717,13 +732,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
-  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
   dependencies:
-    "@babel/runtime" "^7.7.4"
-    "@babel/runtime-corejs3" "^7.7.4"
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -991,6 +1006,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -1220,10 +1243,10 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
+dom-accessibility-api@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz#ef3cdb5d3f0d599d8f9c8b18df2fb63c9793739d"
+  integrity sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -2777,32 +2800,32 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-preact@^10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.1.tgz#9b3ba020547673a231c6cf16f0fbaef0e8863431"
-  integrity sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q==
+preact@^10.4.8:
+  version "10.4.8"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.8.tgz#8517b106cc5591eb675237c93da99ac052cf4756"
+  integrity sha512-uVLeEAyRsCkUEFhVHlOu17OxcrwC7+hTGZ08kBoLBiGHiZooUZuibQnphgMKftw/rqYntNMyhVCPqQhcyAGHag==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-pretty-format@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
-pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.5.0:
+pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
   dependencies:
     "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
+  dependencies:
+    "@jest/types" "^26.3.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
@@ -2838,7 +2861,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-react-is@^16.12.0, react-is@^16.8.4:
+react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -2868,9 +2891,9 @@ realpath-native@^2.0.0:
   integrity sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==
 
 regenerator-runtime@^0.13.4:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -3555,11 +3578,6 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
Closes #6 
Closes #7 
Closes #8

This pull request seeks to sync `@testing-library/preact-hooks` to be brought in line with the latest `@testing-library/react-hooks` (v3.4.1).

Specifically, this includes:

[**v3.4.1**](https://github.com/testing-library/react-hooks-testing-library/releases/tag/v3.4.1)

>- The `wait` async util has been deprecated and replaced with `waitFor` (https://github.com/testing-library/react-hooks-testing-library/pull/408)
>- `waitFor` and `waitForValueToChange` async utils can now test their conditions periodically, even if the hook has not rerendered, using the new `interval` option (https://github.com/testing-library/react-hooks-testing-library/pull/408)

[**v3.3.0**](https://github.com/testing-library/react-hooks-testing-library/releases/tag/v3.3.0)

>- `wrapper` component can now access the `initialProps` and new props from `rerender` calls when creating providers (https://github.com/testing-library/react-hooks-testing-library/issues/322, https://github.com/testing-library/react-hooks-testing-library/pull/381)

[**v3.2.0**](https://github.com/testing-library/react-hooks-testing-library/releases/tag/v3.2.0)

>- Introduced `/pure` inmport as alternative to skip auto cleanup