### PR TITLE
bugfix: Prevent falsy return values from the hook to get overwritten with `undefined`

### DIFF
--- a/src/resultContainer.ts
+++ b/src/resultContainer.ts
@@ -1,7 +1,7 @@
 import { ResolverType } from "./_types";
 
 function resultContainer<R>(initialValue?: R) {
-  let value: R = initialValue as R;
+  let value = initialValue;
   let error: Error;
   const resolvers: ResolverType[] = [];
 
@@ -18,7 +18,7 @@ function resultContainer<R>(initialValue?: R) {
   };
 
   function updateResult(val?: R, err?: Error) {
-    value = val ? val : value;
+    value = val;
     error = err ? err : error;
     resolvers.splice(0, resolvers.length).forEach((resolve) => resolve());
   }

--- a/test/customHook.test.ts
+++ b/test/customHook.test.ts
@@ -1,29 +1,69 @@
 import { useState, useCallback } from "preact/hooks";
 import { renderHook, act } from "../src";
 
-describe("custom hook tests", () => {
-  function useCounter() {
-    const [count, setCount] = useState(0);
+describe("Custom hooks", () => {
+  describe("useCounter", () => {
+    function useCounter() {
+      const [count, setCount] = useState(0);
 
-    const increment = useCallback(() => setCount(count + 1), [count]);
-    const decrement = useCallback(() => setCount(count - 1), [count]);
+      const increment = useCallback(() => setCount(count + 1), [count]);
+      const decrement = useCallback(() => setCount(count - 1), [count]);
 
-    return { count, increment, decrement };
-  }
+      return { count, increment, decrement };
+    }
 
-  test("should increment counter", () => {
-    const { result } = renderHook(() => useCounter());
+    test("should increment counter", () => {
+      const { result } = renderHook(() => useCounter());
 
-    act(() => result.current.increment());
+      act(() => result.current.increment());
 
-    expect(result.current.count).toBe(1);
+      expect(result.current.count).toBe(1);
+    });
+
+    test("should decrement counter", () => {
+      const { result } = renderHook(() => useCounter());
+
+      act(() => result.current.decrement());
+
+      expect(result.current.count).toBe(-1);
+    });
   });
 
-  test("should decrement counter", () => {
-    const { result } = renderHook(() => useCounter());
+  describe("return proper fasly values", () => {
+    type Falsy = 0 | null | undefined | false | "" | undefined;
 
-    act(() => result.current.decrement());
+    function useFalsy(value: Falsy) {
+      return value;
+    }
 
-    expect(result.current.count).toBe(-1);
+    test("`false`", () => {
+      const { result } = renderHook(() => useFalsy(false));
+
+      expect(result.current).toBe(false);
+    });
+
+    test("`0`", () => {
+      const { result } = renderHook(() => useFalsy(0));
+
+      expect(result.current).toBe(0);
+    });
+
+    test("`null`", () => {
+      const { result } = renderHook(() => useFalsy(null));
+
+      expect(result.current).toBe(null);
+    });
+
+    test("`''`", () => {
+      const { result } = renderHook(() => useFalsy(""));
+
+      expect(result.current).toBe("");
+    });
+
+    test("`undefined`", () => {
+      const { result } = renderHook(() => useFalsy(undefined));
+
+      expect(result.current).toBe(undefined);
+    });
   });
 });

--- a/test/customHook.test.ts
+++ b/test/customHook.test.ts
@@ -30,7 +30,7 @@ describe("Custom hooks", () => {
   });
 
   describe("return proper fasly values", () => {
-    type Falsy = 0 | null | undefined | false | "" | undefined;
+    type Falsy = 0 | null | undefined | false | "";
 
     function useFalsy(value: Falsy) {
       return value;


### PR DESCRIPTION
**What/Why**
When testing a hook, which returns a falsy value like `''`, `null` or `0` using the `renderHook` method `result.current` will always be `undefined` instead of the actual falsy value.

**Expected**
To get the actual return value of the hook, even if it is falsy instead of `undefined` all the time.