### PR TITLE
Remove "only" qualifier from asyncHook test case

### DIFF
--- a/test/asyncHook.test.ts
+++ b/test/asyncHook.test.ts
@@ -96,7 +96,7 @@ describe("async hook tests", () => {
     expect(complete).toBe(true);
   });
 
-  test.only("should wait for arbitrary expectation to pass", async () => {
+  test("should wait for arbitrary expectation to pass", async () => {
     const { waitFor } = renderHook(() => null);
 
     let actual = 0;


### PR DESCRIPTION
Mistakenly left in #9

All tests still pass.

The `wait` deprecation message now logs directly to the terminal output in the course of running the tests. While not ideal, this appears to be the same behavior as in running `npm test` in `react-hooks-testing-library`, and doesn't otherwise cause the tests to fail. A better approach may be to suppress console logging ([example](https://stackoverflow.com/a/56677834)).

**Before:**

```
Test Suites: 1 skipped, 13 passed, 13 of 14 total
Tests:       30 skipped, 35 passed, 65 total
```

**After:**

```
Test Suites: 1 skipped, 13 passed, 13 of 14 total
Tests:       8 skipped, 57 passed, 65 total
```