### PR TITLE
Add `lib/` and `.vscode` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,8 @@ dist
 # TernJS port file
 .tern-port
 
-# Stores VSCode versions used for testing VSCode extensions
+# Settings from IDE
+.vscode
 .vscode-test
 
 # yarn v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Build generated
+lib/
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 


### PR DESCRIPTION
The `lib` project is being generated when building the code but we don't want it to be committed. So let's ignore it properly.