### PR TITLE
Fix typing for parity with React

### DIFF
--- a/src/resultContainer.ts
+++ b/src/resultContainer.ts
@@ -1,7 +1,7 @@
 import { ResolverType } from "./_types";
 
-function resultContainer<R>(initialValue?: R) {
-  let value = initialValue;
+function resultContainer<R>() {
+  let value: R | undefined;
   let error: Error;
   const resolvers: ResolverType[] = [];
 
@@ -10,7 +10,7 @@ function resultContainer<R>(initialValue?: R) {
       if (error) {
         throw error;
       }
-      return value;
+      return value as R;
     },
     get error() {
       return error;

--- a/test/customHook.test.ts
+++ b/test/customHook.test.ts
@@ -15,17 +15,17 @@ describe("Custom hooks", () => {
     test("should increment counter", () => {
       const { result } = renderHook(() => useCounter());
 
-      act(() => result.current?.increment());
+      act(() => result.current.increment());
 
-      expect(result.current?.count).toBe(1);
+      expect(result.current.count).toBe(1);
     });
 
     test("should decrement counter", () => {
       const { result } = renderHook(() => useCounter());
 
-      act(() => result.current?.decrement());
+      act(() => result.current.decrement());
 
-      expect(result.current?.count).toBe(-1);
+      expect(result.current.count).toBe(-1);
     });
   });
 

--- a/test/useRef.test.ts
+++ b/test/useRef.test.ts
@@ -27,6 +27,6 @@ describe("useHook tests", () => {
 
     const refContainer = result.current;
 
-    expect(refContainer?.current?.fakeImperativeMethod()).toBe(true);
+    expect(refContainer.current?.fakeImperativeMethod()).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes in this PR get the typing closer to what React's testing library does and thereby makes migrations from React to Preact easier. When I migrated from React to Preact, a TS error appeared as soon as I imported `renderHook` from the Preact testing library:
<img width="605" alt="Screen Shot 2022-02-02 at 3 53 47 PM" src="https://user-images.githubusercontent.com/2785791/153241697-b5b92fb4-96fe-4651-89b8-58169e706e2d.png">

The error says that `result.current` could possibly be undefined, meaning I need to unfortunately refactor `result.current(yo)` to `result.current?.(yo)`.

At first this issue makes sense because the [resultContainer](https://github.com/testing-library/preact-hooks-testing-library/blob/f96eaa4cd9e4663792897d26c40cd274d7c3b6db/src/resultContainer.ts#L3) function has an `initialValue` argument that might be undefined and also the value of `let value` might be undefined. However, the library actually never [calls resultContainer](https://github.com/testing-library/preact-hooks-testing-library/blob/f96eaa4cd9e4663792897d26c40cd274d7c3b6db/src/renderHook.tsx#L20) with an argument, justifying the removal of `initialValue` as a potential argument.

That doesn't solve the potential undefined value though. For this, I'm following the pattern in [React's resultContainer](https://github.com/testing-library/react-hooks-testing-library/blob/e4b0aa3f8f6220a0dea01db25fd2d17fa3054a40/src/core/index.ts#L20) by assigning `value as R`. This way types are safe.

I verified type-safety locally in one of the tests. When I change…
```
const { result } = renderHook(() => useCounter());
...
expect(result.current.count).toBe(1);
```
…to…
```
const { result } = renderHook(() => 'different');
...
expect(result.current.count).toBe(1);
```
…TS throws an error for `result.current.count`, saying that `result.current` can't have a property `count` – which is correct because `result.current` is now of type `string`.